### PR TITLE
Add dark mode hero image

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1446,7 +1446,11 @@ footer {
 }
 
 [data-theme="dark"] .hero {
-  background: linear-gradient(135deg, #1a237e 0%, #311b92 100%);
+ background: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.7)),
+              url("https://images.unsplash.com/photo-1495474472287-4d71bcdd2085?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1200&q=80");
+  background-size: cover;
+  background-position: center;
+  transition: var(--transition); /* smooth transition when toggling dark mode */
 }
 
 [data-theme="dark"] .product-card,


### PR DESCRIPTION
### **Description:**
This PR enhances the hero section of the website by adding a dedicated image for dark mode. Now, when users switch to dark mode, the hero section displays a visually appealing background while keeping the text readable.
### **Changes Made:**
- Added dark mode hero background image in styles.css.
- Updated CSS to ensure smooth transitions when toggling between light and dark mode.
- Verified compatibility with existing theme toggle functionality.
Fix: #50 
### **Screenshots:**
<img width="1918" height="877" alt="Screenshot 2025-10-03 185115" src="https://github.com/user-attachments/assets/4fb3ed10-6ada-416d-baf5-06d97e1e356b" />

