### PR TITLE
fix(toast): show error toast when cart is empty

### DIFF
--- a/script.js
+++ b/script.js
@@ -1173,7 +1173,7 @@ function changeQuantity(name, change) {
 
 function showPaymentSection() {
   if (cart.length === 0) {
-    showToast("Your cart is empty!");
+    showErrorToast("Your cart is empty!");
     return;
   }
 


### PR DESCRIPTION
When checking out with an empty cart a success toast appeared. Replaced **showToast** with **showErrorToast** so the error toast and icon display correctly.